### PR TITLE
Reverting the previously made changes that broke drupal coder

### DIFF
--- a/docker/php/bin/php.sh
+++ b/docker/php/bin/php.sh
@@ -8,29 +8,30 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
     php<PHP_VERSION>-fpm \
     php<PHP_VERSION>-dev \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    php<PHP_VERSION>-acpu \
     php<PHP_VERSION>-bcmath \
     php<PHP_VERSION>-bz2 \
     php<PHP_VERSION>-curl \
-    php<PHP_VERSION>-dba \
 	php<PHP_VERSION>-dom \
+    php<PHP_VERSION>-ds \
     php<PHP_VERSION>-gd \
+    php<PHP_VERSION>-geoip \
     php<PHP_VERSION>-gmp \
 	php<PHP_VERSION>-gnupg \
     php<PHP_VERSION>-http \
     php<PHP_VERSION>-igbinary \
     php<PHP_VERSION>-imagick \
     php<PHP_VERSION>-imap \
+    php<PHP_VERSION>-intl \
     php<PHP_VERSION>-ldap \
     php<PHP_VERSION>-mbstring \
     php<PHP_VERSION>-memcache \
     php<PHP_VERSION>-memcached \
     php<PHP_VERSION>-mysql \
     php<PHP_VERSION>-oauth \
-    php<PHP_VERSION>-pspell \
+    php<PHP_VERSION>-radius \
     php<PHP_VERSION>-soap \
-    php<PHP_VERSION>-tideways \
     php<PHP_VERSION>-tidy \
+    php<PHP_VERSION>-uuid \
     php<PHP_VERSION>-xmlrpc \
     php<PHP_VERSION>-xsl \
     php<PHP_VERSION>-yaml \
@@ -38,6 +39,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y \
 && if [[ "$WEB_PHP_VERSION" == "7.1" ]]; then
 	DEBIAN_FRONTEND=noninteractive apt-get install -y \
     php7.1-ssh2 \
+    php7.1-mcrypt \
     php7.1-xdebug
 elif [[ "$WEB_PHP_VERSION" == "7.2" ]]; then
     DEBIAN_FRONTEND=noninteractive apt-get install -y php-pear \
@@ -67,6 +69,7 @@ elif [[ "$WEB_PHP_VERSION" == "7.2" ]]; then
         php<PHP_VERSION>-xmlreader \
         php<PHP_VERSION>-xmlwriter \
     && pecl install xdebug-2.7.0 \
+	&& pecl install mcrypt-1.0.1 \
     && { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \
@@ -74,7 +77,8 @@ elif [[ "$WEB_PHP_VERSION" == "7.2" ]]; then
         echo 'opcache.revalidate_freq=0'; \
         echo 'opcache.fast_shutdown=1'; \
         echo 'opcache.enable_cli=1'; \
-    } > /etc/php/<PHP_VERSION>/fpm/conf.d/20-opcache.ini
+    } > /etc/php/<PHP_VERSION>/fpm/conf.d/20-opcache.ini \
+    && bash -c "echo extension=mcrypt.so > /etc/php/7.2/fpm/conf.d/mcrypt.ini"
 elif [[ "$WEB_PHP_VERSION" == "7.3" ]]; then
     DEBIAN_FRONTEND=noninteractive apt-get install -y php-pear \
         php<PHP_VERSION>-json \
@@ -105,6 +109,8 @@ elif [[ "$WEB_PHP_VERSION" == "7.3" ]]; then
         php<PHP_VERSION>-xmlreader \
         php<PHP_VERSION>-xmlwriter \
     && pecl install xdebug-2.7.0 \
+	&& pecl install mcrypt-1.0.2 \
+    && bash -c "echo extension=mcrypt.so > /etc/php/7.3/fpm/conf.d/40-mcrypt.ini" \
     && { \
         echo 'opcache.memory_consumption=128'; \
         echo 'opcache.interned_strings_buffer=8'; \


### PR DESCRIPTION
Previous changes that were made resulted in mbstring and other php
extensions failing to be installed, which left us with broken
images.  This PR reverts those changes.

On branch revert-previos-changes

Changes to be committed:
	modified:   docker/php/bin/php.sh